### PR TITLE
Replace implicit SQL literal in filter method.

### DIFF
--- a/lib/sequel/plugins/pg_trgm.rb
+++ b/lib/sequel/plugins/pg_trgm.rb
@@ -3,7 +3,7 @@ module Sequel
     module PgTrgm
       module DatasetMethods
         def text_search(column, query)
-          where("? % ?", column, query).reverse_order{ similarity(column, query) }
+          where(Sequel.lit('? % ?', column, query)).reverse_order{ similarity(column, query) }
         end
       end
     end


### PR DESCRIPTION
Sequel 4.46 deprecated implicitly treating strings in filter methods as
SQL literals, and encourages explicitly using Sequel.lit.

https://github.com/jeremyevans/sequel/blob/master/CHANGELOG#L237